### PR TITLE
docs: expand Development section with build process documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,58 @@ jvm --help
 
 ## Development
 
-To build the project simply run:
+### Prerequisites
+
+- **Java 11+** — required to compile and run (`JAVA_HOME` must be set)
+- **Maven** — provided via the included wrapper (`mvnw` / `mvnw.cmd`), no separate install needed
+
+### Building
+
+Full build with formatting and tests:
 
 ```shell
 ./mvnw spotless:apply clean verify
 ```
- mavern have
+
+Quick build, skipping tests:
+
+```shell
+./mvnw clean package -DskipTests
+```
+
+The build produces two JARs in `target/`:
+
+- `jvm-<version>.jar` — thin JAR (no bundled dependencies)
+- `jvm-<version>-cli.jar` — fat JAR, runnable directly
+
+### Running the Built Artifact
+
+```shell
+java -jar target/jvm-<version>-cli.jar --help
+java -jar target/jvm-<version>-cli.jar --version
+java -jar target/jvm-<version>-cli.jar list
+```
+
+Or use the assembled launcher from `target/binary/bin/`:
+
+```shell
+# Linux/macOS
+./target/binary/bin/jvm --help
+# Windows
+target\binary\bin\jvm.bat --help
+```
+
+### Code Formatting
+
+The project uses [Spotless](https://github.com/diffplug/spotless) with Google Java Format (AOSP style).
+
+```shell
+# Apply formatting
+./mvnw spotless:apply
+# Check without modifying
+./mvnw spotless:check
+```
+
 ### Building Native Executables
 
 The project supports building native executables using GraalVM. This creates a standalone binary with faster startup time and lower memory footprint.


### PR DESCRIPTION
## Summary

Expands the Development section of the README with complete build process documentation.

## Changes

- **Prerequisites** — Java 11+ and Maven wrapper requirements
- **Building** — full build (spotless:apply clean verify) and quick build (-DskipTests) with artifact descriptions for both the thin JAR and fat CLI JAR
- **Running** — how to invoke the built artifact directly via java -jar and via the assembled launcher in 	arget/binary/bin/
- **Code Formatting** — spotless:apply vs spotless:check usage
- **Typo fix** — removed stray \mavern have\ text from the original Development section

## Verification

The documented commands were verified against a successful local build producing \jvm-0.3.1-SNAPSHOT-cli.jar\, confirmed runnable with \--version\ and \--help\.

---

[Warp conversation](https://app.warp.dev/conversation/d4605282-c8f4-4060-b338-188c7617726a)

Co-Authored-By: Oz <oz-agent@warp.dev>